### PR TITLE
fix: sync version to v1.3.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [1.3.0](https://github.com/ThilinaV98/sample-semrel/compare/v1.2.0...v1.3.0) (2025-09-11)
+
+### Features
+
+* add feature A functionality ([d05175a](https://github.com/ThilinaV98/sample-semrel/commit/d05175a))
+
+### Bug Fixes
+
+* resolve critical bug in authentication ([fb433c7](https://github.com/ThilinaV98/sample-semrel/commit/fb433c7))
+
+### Performance Improvements
+
+* optimize database queries ([12872dc](https://github.com/ThilinaV98/sample-semrel/commit/12872dc))
+
+## [1.2.0](https://github.com/ThilinaV98/sample-semrel/compare/v1.1.1...v1.2.0) (2025-09-11)
+
+### Features
+
+* add new versioning test feature ([1fd766c](https://github.com/ThilinaV98/sample-semrel/commit/1fd766c))
+
 ## [1.1.1](https://github.com/username/sample-semantic-release/compare/v1.1.0...v1.1.1) (2025-09-11)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-semantic-release",
-  "version": "1.1.1",
+  "version": "1.3.0",
   "description": "Sample project demonstrating semantic versioning and branching strategy",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Resolves version mismatch between GitHub releases and repository files
- Updates package.json from v1.1.1 to v1.3.0
- Adds missing changelog entries for v1.2.0 and v1.3.0

## Problem
The semantic-release workflow created GitHub releases (v1.2.0) but the version updates weren't properly committed back to the main branch, causing:
- package.json showing v1.1.1
- CHANGELOG.md missing v1.2.0 and v1.3.0 entries
- GitHub releases showing v1.2.0 while repo files show v1.1.1

## Solution
This PR manually syncs the version to v1.3.0 to account for:
- v1.2.0: Feature from PR #10 (test versioning feature)
- v1.3.0: Features from PR #11 (feature A, bug fix, performance optimization)

## Changes
- 📦 package.json: Update version to 1.3.0
- 📝 CHANGELOG.md: Add v1.2.0 and v1.3.0 entries with proper commit references